### PR TITLE
SafeSnap: fix a bug when `data` is an empty string

### DIFF
--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -314,11 +314,9 @@ export default class Plugin {
     };
     return transactions.map((tx) => {
       const txHash = _TypedDataEncoder.hash(domain, EIP712_TYPES, {
-        // @ts-ignore
-        nonce: '0',
-        // @ts-ignore
-        data: '0x',
-        ...tx
+        ...tx,
+        nonce: tx.nonce || '0',
+        data: tx.data || '0x'
       });
       return txHash;
     });


### PR DESCRIPTION
When the `data` field is set to an empty string (which is the default value when crafting raw transactions), hashing fails. We now correctly fall back to `"0x"` as default value.

The problem manifested itself when creating a proposal with a single raw transaction. JavaScript error:
```
Error: invalid arrayify value (argument="value", value="", code=INVALID_ARGUMENT, version=bytes/5.4.0)
```
Example: https://snapshot.org/#/thanku.eth/proposal/QmWnnEtyZoNTqTVrz6v3u29iSv1MGms9S2qVpAzRgahow8