### PR TITLE
return tx to allow waiting for it in snapshot ui

### DIFF
--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -395,15 +395,13 @@ export default class Plugin {
       moduleAddress,
       transactions
     );
-    const tx = await sendTransaction(
+    return await sendTransaction(
       web3,
       moduleAddress,
       ModuleAbi,
       'addProposal',
       [proposalId, txHashes]
     );
-    const receipt = await tx.wait();
-    console.log('[DAO module] submitted proposal:', receipt);
   }
 
   async loadClaimBondData(
@@ -520,31 +518,28 @@ export default class Plugin {
       [questionId]
     ]);
 
-    if (BigNumber.from(currentHistoryHash).eq(0)) {
-      const tx = await sendTransaction(
+    let tx: any;
+    const multi = !BigNumber.from(currentHistoryHash).eq(0);
+
+    if (multi) {
+      tx = await sendTransaction(
+        web3,
+        oracleAddress,
+        OracleAbi,
+        'claimMultipleAndWithdrawBalance',
+        [[questionId], ...claimParams]
+      );
+    } else {
+      tx = await sendTransaction(
         web3,
         oracleAddress,
         OracleAbi,
         'withdraw',
         []
       );
-      const receipt = await tx.wait();
-      console.log('[Realitio] executed withdraw:', receipt);
-      return;
     }
 
-    const tx = await sendTransaction(
-      web3,
-      oracleAddress,
-      OracleAbi,
-      'claimMultipleAndWithdrawBalance',
-      [[questionId], ...claimParams]
-    );
-    const receipt = await tx.wait();
-    console.log(
-      '[Realitio] executed claimMultipleAndWithdrawBalance:',
-      receipt
-    );
+    return { tx, multi };
   }
 
   async executeProposal(

--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -555,7 +555,7 @@ export default class Plugin {
       transactions
     );
     const moduleTx = transactions[transactionIndex];
-    const tx = await sendTransaction(
+    return await sendTransaction(
       web3,
       moduleAddress,
       ModuleAbi,
@@ -570,8 +570,6 @@ export default class Plugin {
         transactionIndex
       ]
     );
-    const receipt = await tx.wait();
-    console.log('[DAO module] executed proposal:', receipt);
   }
 
   async voteForQuestion(


### PR DESCRIPTION
Related to: https://github.com/snapshot-labs/snapshot/issues/666

The UI is supposed to display different loading states for `button click -> wallet confirm` and `wallet confirm -> tx confirmed`. That is only possible if we move `tx.wait()` to the UI.

Changed that for all functions in the plugin, except this:

https://github.com/snapshot-labs/snapshot-plugins/blob/590c71d69768b372884195fa3fa8ad6dc47631be/src/plugins/safeSnap/index.ts#L631-L662

Not entirely sure about how to handle this.

The check for RealityERC20 should probably be also performed in the UI instead of being kind of sneeked in inside of `voteForQuestion` function.