### PR TITLE
Workflow to automatically update submodule in snapshot repo

### DIFF
--- a/.github/workflows/update-snapshot-submodule.yml
+++ b/.github/workflows/update-snapshot-submodule.yml
@@ -1,5 +1,6 @@
 name: Update Snapshot Submodule
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
Suggestion: This workflow will automatically update the `snapshot-plugins` submodule in the snapshot repo whenever there are changes in the `src` directory or the package files.

**Currently this won't run at all** because it targets a branch named `main` which does not exist. But I suggest renaming `master` to `develop` (so it continues to be the repo's default branch) and adding a `main` branch.

Then we can work on `develop` and whenever we merge changes into `main` the submodule in the snapshot repo will be updated to the latest commit. Quick fixes or so can still be made directly on `main` then. They just should be merged back into `develop`.

Same PR for snapshot-spaces: https://github.com/snapshot-labs/snapshot-spaces/pull/1629

Related PR in snapshot repo: https://github.com/snapshot-labs/snapshot/pull/899

**This will require to set a personal access token as a secret (`UPDATE_SNAPSHOT_PAT`) on repository or org level, with the `public_repo` scope.**
