### PR TITLE
[safesnap] pass tuple as a param for contract interactions

### DIFF
--- a/src/plugins/safeSnap/utils/abi.ts
+++ b/src/plugins/safeSnap/utils/abi.ts
@@ -11,6 +11,10 @@ import { ERC20_ABI, ERC721_ABI, EXPLORER_API_URLS } from '../constants';
 import { ABI } from '../models';
 import { mustBeEthereumAddress, mustBeEthereumContractAddress } from './index';
 
+export function isArrayParameter(parameter: string): boolean {
+  return ['tuple', 'array'].includes(parameter);
+}
+
 const fetchContractABI = memoize(
   async (url: string, contractAddress: string) => {
     const params = new URLSearchParams({
@@ -90,7 +94,7 @@ export function getABIWriteFunctions(abi: Fragment[]) {
 function extractMethodArgs(values: string[]) {
   return (param: ParamType, index) => {
     const value = values[index];
-    if (param.baseType === 'array') {
+    if (isArrayParameter(param.baseType)) {
       return JSON.parse(value);
     }
     return value;

--- a/src/plugins/safeSnap/utils/decoder.ts
+++ b/src/plugins/safeSnap/utils/decoder.ts
@@ -4,6 +4,7 @@ import {
   Fragment,
   JsonFragment
 } from '@ethersproject/abi';
+import { isArrayParameter } from './abi';
 
 export class InterfaceDecoder extends Interface {
   public decodeFunction(
@@ -44,7 +45,7 @@ export class InterfaceDecoder extends Interface {
   }
 
   private formatParameter(parameter, value, deep = 0): string {
-    if (parameter.baseType === 'array') {
+    if (isArrayParameter(parameter.baseType)) {
       return this.formatArrayValue(parameter.arrayChildren, value, deep);
     }
     return this.formatValue(parameter.type, value);


### PR DESCRIPTION
### Summary
To create transactions with functions having a param of type Tuple, the array needs to be parsed before creating the transaction.