### PR TITLE
note about new plugin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Deprecated!
+
+**Plugins have been moved to the [snapshot UI repository](https://github.com/snapshot-labs/snapshot). Please refer to the [documentation](https://docs.snapshot.org/plugins), to read more about plugin development.**
+
 # Snapshot plugins
 
 ### Development


### PR DESCRIPTION
Once this https://github.com/snapshot-labs/snapshot/pull/1717 is merged, we can archive this repository and add this note to the readme. [Docs](https://docs.snapshot.org/plugins/create) have been updated too.